### PR TITLE
Add support for PHP 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.3, 8.4 ]
+        php: [ 8.4, 8.5 ]
         laravel: [ 11.*, 12.* ]
         stability: [ prefer-lowest, prefer-stable ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,22 @@ jobs:
         stability: [ prefer-lowest, prefer-stable ]
 
     steps:
-      - name: Checkout code
+      - name: Check out code
         uses: actions/checkout@v5
+
+      - name: Cache PHP dependencies
+        uses: actions/cache@v3
+        with:
+          path: '**/vendor'
+          key: ${{ runner.os }}-vendor-cache-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-vendor-cache-
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: composer-${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('composer.json') }}
 
       - name: Validate Composer configuration file
         run: composer validate --strict
@@ -32,8 +46,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/database:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer require "illuminate/database:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update --no-progress --optimize-autoloader
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress --optimize-autoloader
 
       - name: Lint code
         run: vendor/bin/pint --test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All Notable changes to `sebastiaanluca/laravel-boolean-dates` will be documented
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## 10.0.0 (Unreleased)
+
+### Added
+
+- Added support for PHP 8.5
+
+### Removed
+
+- Dropped support for PHP 8.3
+
 ## 9.0.0 (2025-02-07)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All Notable changes to `sebastiaanluca/laravel-boolean-dates` will be documented
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## 10.0.0 (Unreleased)
+## 10.0.0 (2025-11-28)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $user->accepted_terms_at;
 
 ## Requirements
 
-- PHP 8.3 or 8.4
+- PHP 8.4 or 8.5
 - Laravel 11 or 12
 
 ## How to install

--- a/README.md
+++ b/README.md
@@ -294,7 +294,6 @@ Have a project that could use some guidance? Send me an e-mail at [hello@sebasti
 
 [link-github]: https://github.com/sebastiaanluca/laravel-boolean-dates
 [link-packagist]: https://packagist.org/packages/sebastiaanluca/laravel-boolean-dates
-[link-travis]: https://travis-ci.org/sebastiaanluca/laravel-boolean-dates
 [link-twitter-share]: https://twitter.com/intent/tweet?text=Easily%20convert%20Eloquent%20model%20booleans%20to%20dates%20and%20back%20with%20Laravel%20Boolean%20Dates.%20Via%20@sebastiaanluca%20https://github.com/sebastiaanluca/laravel-boolean-dates
 [link-contributors]: ../../contributors
 

--- a/composer.json
+++ b/composer.json
@@ -84,8 +84,6 @@
         "test:stable": [
             "composer update --prefer-stable --prefer-dist --no-interaction --ansi",
             "@test"
-        ],
-
-        "release": "git-release"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
     "prefer-stable": true,
     "scripts": {
         "post-update-cmd": [
-            "@fix"
+            "@fix",
+            "composer bump"
         ],
 
         "validate:composer": "@composer validate --strict --ansi",

--- a/composer.json
+++ b/composer.json
@@ -26,15 +26,15 @@
     ],
     "require": {
         "php": "^8.4.0",
-        "illuminate/database": "^11.32|^12.0",
-        "illuminate/support": "^11.32|^12.0"
+        "illuminate/database": "^11.32|^12.40.2",
+        "illuminate/support": "^11.32|^12.40.2"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.68.5",
-        "laravel/pint": "^1.20",
-        "laravel/serializable-closure": "^2.0",
-        "phpunit/phpunit": "^11.5.7",
-        "rector/rector": "^1.2.10",
+        "friendsofphp/php-cs-fixer": "^3.90.0",
+        "laravel/pint": "^1.26",
+        "laravel/serializable-closure": "^2.0.7",
+        "phpunit/phpunit": "^11.5.44",
+        "rector/rector": "^2.2.9",
         "roave/security-advisories": "dev-latest"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^8.3.0",
+        "php": "^8.4.0",
         "illuminate/database": "^11.32|^12.0",
         "illuminate/support": "^11.32|^12.0"
     },

--- a/rector.php
+++ b/rector.php
@@ -8,8 +8,6 @@ use Rector\Config\RectorConfig;
 use Rector\EarlyReturn\Rector\If_\ChangeOrIfContinueToMultiContinueRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
-use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
-use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return RectorConfig::configure()
@@ -29,17 +27,12 @@ return RectorConfig::configure()
         typeDeclarations: true,
         privatization: true,
         earlyReturn: true,
-        strictBooleans: true,
     )
     ->withSets([
         PHPUnitSetList::PHPUNIT_80,
         PHPUnitSetList::PHPUNIT_90,
         PHPUnitSetList::PHPUNIT_100,
         PHPUnitSetList::PHPUNIT_110,
-    ])
-    ->withRules([
-        ReadOnlyClassRector::class,
-        ReadOnlyPropertyRector::class,
     ])
     ->withSkip([
         CatchExceptionNameMatchingTypeRector::class,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds PHP 8.5 support, drops 8.3, updates CI (matrix, caching), bumps dependency constraints (incl. Laravel 12.40.2), and refreshes tooling and docs.
> 
> - **Breaking/Support**:
>   - Require `php` ^8.4; add support for PHP 8.5; drop PHP 8.3 (`composer.json`, `README.md`, `CHANGELOG.md`).
> - **CI** (`.github/workflows/test.yml`):
>   - Update matrix to `php: [8.4, 8.5]` and `actions/checkout@v5`.
>   - Add caching for `vendor` and Composer cache.
>   - Use `--no-progress --optimize-autoloader` in Composer commands.
> - **Dependencies** (`composer.json`):
>   - Bump `illuminate/database` and `illuminate/support` to `^11.32|^12.40.2`.
>   - Update dev deps: `phpunit`, `pint`, `php-cs-fixer`, `rector`.
>   - Scripts: add `composer bump` to `post-update-cmd`; remove `release` script.
> - **Tooling** (`rector.php`):
>   - Simplify prepared sets (remove strict booleans); remove read-only class/property rules.
> - **Docs**:
>   - Update requirements and changelog for new PHP support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddd94eefc2134fffedf458b3e4daa0ab0b00cae5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->